### PR TITLE
fix half-pixel offsets

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -76,6 +76,10 @@ fn make_canvas_color(color: BackendColor) -> JsValue {
     format!("rgba({},{},{},{})", r, g, b, a).into()
 }
 
+fn to_f64_offset(x: i32) -> f64 {
+    f64::from(x) + 0.5
+}
+
 impl DrawingBackend for CanvasBackend {
     type ErrorType = CanvasError;
 
@@ -119,8 +123,11 @@ impl DrawingBackend for CanvasBackend {
 
         self.set_line_style(style);
         self.context.begin_path();
-        self.context.move_to(f64::from(from.0), f64::from(from.1));
-        self.context.line_to(f64::from(to.0), f64::from(to.1));
+        self.context.set_line_cap("square");
+        self.context
+            .move_to(to_f64_offset(from.0), to_f64_offset(from.1));
+        self.context
+            .line_to(to_f64_offset(to.0), to_f64_offset(to.1));
         self.context.stroke();
         Ok(())
     }
@@ -147,10 +154,10 @@ impl DrawingBackend for CanvasBackend {
         } else {
             self.set_line_style(style);
             self.context.stroke_rect(
-                f64::from(upper_left.0),
-                f64::from(upper_left.1),
-                f64::from(bottom_right.0 - upper_left.0),
-                f64::from(bottom_right.1 - upper_left.1),
+                to_f64_offset(upper_left.0),
+                to_f64_offset(upper_left.1),
+                to_f64_offset(bottom_right.0 - upper_left.0),
+                to_f64_offset(bottom_right.1 - upper_left.1),
             );
         }
         Ok(())
@@ -166,11 +173,14 @@ impl DrawingBackend for CanvasBackend {
         }
         let mut path = path.into_iter();
         self.context.begin_path();
+        self.context.set_line_cap("square");
         if let Some(start) = path.next() {
             self.set_line_style(style);
-            self.context.move_to(f64::from(start.0), f64::from(start.1));
+            self.context
+                .move_to(to_f64_offset(start.0), to_f64_offset(start.1));
             for next in path {
-                self.context.line_to(f64::from(next.0), f64::from(next.1));
+                self.context
+                    .line_to(to_f64_offset(next.0), to_f64_offset(next.1));
             }
         }
         self.context.stroke();
@@ -190,9 +200,11 @@ impl DrawingBackend for CanvasBackend {
         if let Some(start) = path.next() {
             self.context
                 .set_fill_style(&make_canvas_color(style.color()));
-            self.context.move_to(f64::from(start.0), f64::from(start.1));
+            self.context
+                .move_to(to_f64_offset(start.0), to_f64_offset(start.1));
             for next in path {
-                self.context.line_to(f64::from(next.0), f64::from(next.1));
+                self.context
+                    .line_to(to_f64_offset(next.0), to_f64_offset(next.1));
             }
             self.context.close_path();
         }
@@ -219,8 +231,8 @@ impl DrawingBackend for CanvasBackend {
         self.context.begin_path();
         self.context
             .arc(
-                f64::from(center.0),
-                f64::from(center.1),
+                to_f64_offset(center.0),
+                to_f64_offset(center.1),
                 f64::from(radius),
                 0.0,
                 std::f64::consts::PI * 2.0,


### PR DESCRIPTION
In 38/plotters#165 the tick lines look like they're two pixels wide instead of one as intended, as well as at half opacity, which would indicate that the error comes from the line being rendered on the border between two pixel rows instead of within one row of pixels.

This change moves line endpoints by +0.5 in both the x and y direction so that the endpoints lie in the centers of pixels. That by itself however would leave the pixels at the line ends only half-covered, so we need to add the [square linecap](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap) to the lines which then completely fills up the endpoint pixels.

Here is the new behaviour of the wasm-demo example when selecting "Graph of y=x^3" in the drop-down.
![canvas-1](https://user-images.githubusercontent.com/18399125/155851567-5acdb6fb-7514-4b41-badf-627ab301b062.png)
![canvas-2](https://user-images.githubusercontent.com/18399125/155851570-709252c1-427e-4d01-a6bb-01e94ab67c36.png)
![canvas-3](https://user-images.githubusercontent.com/18399125/155851571-093ef5c4-852b-4001-9a03-aa62d69d0b1b.png)

A downside of this approach is that this slightly changes the behaviour of line-width. A LineSeries with width 20 will now continue for 10 more pixels on either side. Is this a problem? See example here:

![image](https://user-images.githubusercontent.com/18399125/155851903-6a4769ac-62f8-4932-bc4c-238eacad8911.png)
