### PR TITLE
Proposal to use git-master dependencies for collaboration, testing, and CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.plotters-backend]
-branch = "master"
 git = "https://github.com/plotters-rs/plotters-backend"
 # version = "0.3.1"
 
@@ -28,7 +27,6 @@ features = ['Document', 'DomRect', 'Element', 'HtmlElement', 'Node', 'Window', '
 wasm-bindgen-test = "^0.3.17"
 
 [dev-dependencies.plotters]
-branch = "master"
 default_features = false
 git = "https://github.com/plotters-rs/plotters"
 # version = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.plotters-backend]
-version = "0.3"
+branch = "master"
+git = "https://github.com/plotters-rs/plotters-backend"
+# version = "0.3.1"
 
 [dependencies]
 js-sys= "0.3.32"
@@ -23,5 +25,10 @@ version = "0.3.32"
 features = ['Document', 'DomRect', 'Element', 'HtmlElement', 'Node', 'Window', 'HtmlCanvasElement', 'CanvasRenderingContext2d']
 
 [dev-dependencies]
-plotters = "^0.3.0"
 wasm-bindgen-test = "^0.3.17"
+
+[dev-dependencies.plotters]
+branch = "master"
+default_features = false
+git = "https://github.com/plotters-rs/plotters"
+# version = "0.3.1"

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -252,6 +252,7 @@ impl DrawingBackend for CanvasBackend {
             FontTransform::Rotate90 => 90.0,
             FontTransform::Rotate180 => 180.0,
             FontTransform::Rotate270 => 270.0,
+            FontTransform::RotateAngle(angle) => angle as f64,
         } / 180.0
             * std::f64::consts::PI;
 


### PR DESCRIPTION
This proposal aims to improve collaboration, testing, and CI by altering the version of the `plotters-backend` and `plotters` dependencies in `Cargo.toml`. Instead of using the stable version of those crates, the `git-master` versions are used.

Using the `git-master` versions of the `plotters-` crates is vital for pre-release quality assurance and frustration-free collaboration in Plotters. It also reduces surprises at release time.

This is part of the proposal discussed on plotters-rs/plotters#373