### PR TITLE
Revert FontTransform::RotateAngle commit

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -252,7 +252,6 @@ impl DrawingBackend for CanvasBackend {
             FontTransform::Rotate90 => 90.0,
             FontTransform::Rotate180 => 180.0,
             FontTransform::Rotate270 => 270.0,
-            FontTransform::RotateAngle(angle) => angle as f64,
         } / 180.0
             * std::f64::consts::PI;
 


### PR DESCRIPTION
This reverts commit 1b3414a4e76c285bea3f818575ce616a85bb581f.

That commit's purpose was to provide coverage of a new FontTransform enum element that was added to the plotters lib, but the element was subsequently removed in [plotters commit 6bd3004](https://github.com/plotters-rs/plotters/commit/6bd30045e545e7308b1349c6ffaaa22a4c6eeb94)