### PR TITLE
Improved canvas size getter to support high-dpi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ examples/wasm-demo/www/pkg
 examples/.ipynb_checkpoints/
 tarpaulin-report.html
 .vscode/*
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ wasm-bindgen = "0.2.55"
 
 [dependencies.web-sys]
 version = "0.3.32"
-features = ['Document', 'DomRect', 'Element', 'HtmlElement', 'Node', 'Window', 'HtmlCanvasElement', 'CanvasRenderingContext2d']
+features = ['Document', 'DomRect', 'Element', 'HtmlElement', 'Node', 'Window', 'HtmlCanvasElement', 'CanvasRenderingContext2d', 'CssStyleDeclaration']
 
 [dev-dependencies]
 plotters = "^0.3.0"

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use js_sys::JSON;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{window, CanvasRenderingContext2d, HtmlCanvasElement};
@@ -80,7 +81,13 @@ impl DrawingBackend for CanvasBackend {
     type ErrorType = CanvasError;
 
     fn get_size(&self) -> (u32, u32) {
-        (self.canvas.width(), self.canvas.height())
+        let style = window().unwrap()
+          .get_computed_style(&self.canvas)
+          .unwrap().unwrap();
+        let width = style.get_property_value("width").unwrap().replace("px", "");
+        let height = style.get_property_value("height").unwrap().replace("px", "");
+        (u32::from_str(&width).unwrap(),
+         u32::from_str(&height).unwrap())
     }
 
     fn ensure_prepared(&mut self) -> Result<(), DrawingErrorKind<CanvasError>> {


### PR DESCRIPTION
In order to support high-dpi in HTML canvas, we need to scale the canvas size by devicePixelRatio first, and then use CSS style to configure the actual size, please see:
https://www.kirupa.com/canvas/canvas_high_dpi_retina.htm

The Canvas scaling part can be handled outside of this library, but in the `get_size` function, we need to get the size from the computed style, not the canvas, which may have been scaled.